### PR TITLE
Add Releases to search query

### DIFF
--- a/src/schema.gql
+++ b/src/schema.gql
@@ -262,12 +262,47 @@ type Title {
   title: String!
 }
 
+type Group {
+  """Group Id"""
+  id: Int!
+
+  """Name of the group"""
+  name: String!
+}
+
+type Search {
+  """Total pages"""
+  totalPages: Int!
+
+  """Page number"""
+  page: Int!
+
+  """Items per page"""
+  perPage: Items!
+  items: [SearchResultUnion!]!
+}
+
+"""Items"""
+enum Items {
+  Five
+  Ten
+  Fifteen
+  TwentyFive
+  Thirty
+  Forty
+  Fifty
+  SeventyFive
+  OneHundred
+}
+
+union SearchResultUnion = SeriesSearchItem | ReleaseSearchItem
+
 type SeriesSearchItem {
   """Series Id"""
   id: Int!
 
   """Title of the series"""
-  title: String!
+  name: String!
 
   """Truncated description of the series"""
   description: String!
@@ -303,44 +338,6 @@ type ReleaseSearchItem {
 
   """Groups that released the chapter"""
   groups: [Group!]!
-}
-
-type Group {
-  """Group Id"""
-  id: Int!
-
-  """Name of the group"""
-  name: String!
-}
-
-type Search {
-  """Total pages"""
-  totalPages: Int!
-
-  """Page number"""
-  page: Int!
-
-  """Items per page"""
-  perPage: Items!
-
-  """Series result"""
-  series: [SeriesSearchItem!]
-
-  """Releases result"""
-  releases: [ReleaseSearchItem!]
-}
-
-"""Items"""
-enum Items {
-  Five
-  Ten
-  Fifteen
-  TwentyFive
-  Thirty
-  Forty
-  Fifty
-  SeventyFive
-  OneHundred
 }
 
 type Query {

--- a/src/schema.gql
+++ b/src/schema.gql
@@ -254,6 +254,14 @@ type Category {
   name: String!
 }
 
+type Title {
+  """Series Id"""
+  id: Int!
+
+  """Title of the series"""
+  title: String!
+}
+
 type SeriesSearchItem {
   """Series Id"""
   id: Int!
@@ -280,6 +288,31 @@ type SeriesSearchItem {
   genres: [MangaGenre!]!
 }
 
+type ReleaseSearchItem {
+  """When the release came out"""
+  date: DateTime!
+
+  """Title of the release"""
+  title: Title!
+
+  """Volume"""
+  volume: String!
+
+  """Chapter of the release"""
+  chapter: String!
+
+  """Groups that released the chapter"""
+  groups: [Group!]!
+}
+
+type Group {
+  """Group Id"""
+  id: Int!
+
+  """Name of the group"""
+  name: String!
+}
+
 type Search {
   """Total pages"""
   totalPages: Int!
@@ -292,6 +325,9 @@ type Search {
 
   """Series result"""
   series: [SeriesSearchItem!]
+
+  """Releases result"""
+  releases: [ReleaseSearchItem!]
 }
 
 """Items"""

--- a/src/search/entities/search.entity.ts
+++ b/src/search/entities/search.entity.ts
@@ -1,4 +1,11 @@
-import { ObjectType, Field, Int, InputType, Float } from '@nestjs/graphql';
+import {
+  ObjectType,
+  Field,
+  Int,
+  InputType,
+  Float,
+  GraphQLISODateTime,
+} from '@nestjs/graphql';
 import { SeriesGenre } from 'src/series/entities/type.enum';
 import { ItemsPerPage, OrderBy, ResultType } from './search.enum';
 
@@ -35,6 +42,44 @@ export class SeriesSearchItem {
 }
 
 @ObjectType()
+export class ReleaseSearchItem {
+  @Field(() => GraphQLISODateTime, {
+    description: 'When the release came out',
+  })
+  date: Date;
+
+  @Field(() => Title, { description: 'Title of the release' })
+  title: Title;
+
+  @Field(() => String, { description: 'Volume' })
+  volume: string;
+
+  @Field(() => String, { description: 'Chapter of the release' })
+  chapter: string;
+
+  @Field(() => [Group], { description: 'Groups that released the chapter' })
+  groups: Group[];
+}
+
+@ObjectType()
+export class Title {
+  @Field(() => Int, { description: 'Series Id' })
+  id: number;
+
+  @Field({ description: 'Title of the series' })
+  title: string;
+}
+
+@ObjectType()
+export class Group {
+  @Field(() => Int, { description: 'Group Id' })
+  id: number;
+
+  @Field({ description: 'Name of the group' })
+  name: string;
+}
+
+@ObjectType()
 export class Search {
   @Field(() => Int, { description: 'Total pages' })
   totalPages: number;
@@ -52,6 +97,12 @@ export class Search {
     nullable: true,
   })
   series?: SeriesSearchItem[];
+
+  @Field(() => [ReleaseSearchItem], {
+    description: 'Releases result',
+    nullable: true,
+  })
+  releases?: ReleaseSearchItem[];
 }
 
 @InputType()

--- a/src/search/entities/search.entity.ts
+++ b/src/search/entities/search.entity.ts
@@ -5,6 +5,7 @@ import {
   InputType,
   Float,
   GraphQLISODateTime,
+  createUnionType,
 } from '@nestjs/graphql';
 import { SeriesGenre } from 'src/series/entities/type.enum';
 import { ItemsPerPage, OrderBy, ResultType } from './search.enum';
@@ -24,7 +25,7 @@ export class SeriesSearchItem {
   id: number;
 
   @Field({ description: 'Title of the series' })
-  title: string;
+  name: string;
 
   @Field({ description: 'Truncated description of the series' })
   description: string;
@@ -92,17 +93,8 @@ export class Search {
   })
   perPage?: ItemsPerPage;
 
-  @Field(() => [SeriesSearchItem], {
-    description: 'Series result',
-    nullable: true,
-  })
-  series?: SeriesSearchItem[];
-
-  @Field(() => [ReleaseSearchItem], {
-    description: 'Releases result',
-    nullable: true,
-  })
-  releases?: ReleaseSearchItem[];
+  @Field(() => [SearchResultUnion])
+  items: Array<typeof SearchResultUnion>;
 }
 
 @InputType()
@@ -144,3 +136,8 @@ export class SearchInput {
   })
   perPage?: ItemsPerPage;
 }
+
+export const SearchResultUnion = createUnionType({
+  name: 'SearchResultUnion',
+  types: () => [SeriesSearchItem, ReleaseSearchItem],
+});

--- a/src/search/entities/search.entity.ts
+++ b/src/search/entities/search.entity.ts
@@ -10,6 +10,15 @@ import { SeriesGenre } from 'src/series/entities/type.enum';
 import { ItemsPerPage, OrderBy, ResultType } from './search.enum';
 
 @ObjectType()
+export class Title {
+  @Field(() => Int, { description: 'Series Id' })
+  id: number;
+
+  @Field({ description: 'Title of the series' })
+  title: string;
+}
+
+@ObjectType()
 export class SeriesSearchItem {
   @Field(() => Int, { description: 'Series Id' })
   id: number;
@@ -59,15 +68,6 @@ export class ReleaseSearchItem {
 
   @Field(() => [Group], { description: 'Groups that released the chapter' })
   groups: Group[];
-}
-
-@ObjectType()
-export class Title {
-  @Field(() => Int, { description: 'Series Id' })
-  id: number;
-
-  @Field({ description: 'Title of the series' })
-  title: string;
 }
 
 @ObjectType()

--- a/src/search/parsers/ReleaseSearchParser.ts
+++ b/src/search/parsers/ReleaseSearchParser.ts
@@ -1,0 +1,60 @@
+import { CheerioAPI } from 'cheerio';
+import { parse } from 'date-fns';
+import { Parser } from 'src/shared/Parser';
+import SharedFunctions from 'src/shared/SharedMethods';
+import { Group, ReleaseSearchItem, Title } from '../entities/search.entity';
+
+export class ReleaseSearchParser implements Parser<ReleaseSearchItem[]> {
+  searchItems: ReleaseSearchItem[] = [];
+
+  public async parse($: CheerioAPI): Promise<void> {
+    const dates = $('.row.no-gutters > .col-2.text')
+      .toArray()
+      .map((element, i) => {
+        return $(element).text();
+      });
+
+    const titlesAndGroups = $('.row.no-gutters > .col-4.text');
+
+    const titles = titlesAndGroups.filter((i, element) => i % 2 === 0);
+    const groups = titlesAndGroups.filter((i, element) => i % 2 === 1);
+
+    const volumeAndChapter = $('.col-1.text.text-center');
+
+    const volumes = volumeAndChapter.filter((i, element) => i % 2 === 0);
+    const chapters = volumeAndChapter.filter((i, element) => i % 2 === 1);
+
+    for (let x = 0; x < dates.length; x += 1) {
+      const release = new ReleaseSearchItem();
+      release.date = this.stringToDate(dates[x]);
+      release.title = new Title();
+      release.title.title = $(titles[x]).text();
+      release.title.id = SharedFunctions.getIdfromURL(
+        $(titles[x]).find('a').attr('href'),
+      );
+      release.volume = $(volumes[x]).text();
+      release.chapter = $(chapters[x]).text();
+
+      release.groups = [
+        ...$(groups[x])
+          .find('a')
+          .map((k, element) => {
+            const group = new Group();
+            group.id = SharedFunctions.getIdfromURL($(element).attr('href'));
+            group.name = $(element).text();
+            return group;
+          }),
+      ];
+
+      this.searchItems.push(release);
+    }
+  }
+
+  public getObject() {
+    return this.searchItems;
+  }
+
+  private stringToDate(s: string): Date {
+    return parse(s, 'MM/dd/yy', new Date());
+  }
+}

--- a/src/search/parsers/ReleaseSearchParser.ts
+++ b/src/search/parsers/ReleaseSearchParser.ts
@@ -10,19 +10,19 @@ export class ReleaseSearchParser implements Parser<ReleaseSearchItem[]> {
   public async parse($: CheerioAPI): Promise<void> {
     const dates = $('.row.no-gutters > .col-2.text')
       .toArray()
-      .map((element, i) => {
+      .map((element, _) => {
         return $(element).text();
       });
 
     const titlesAndGroups = $('.row.no-gutters > .col-4.text');
 
-    const titles = titlesAndGroups.filter((i, element) => i % 2 === 0);
-    const groups = titlesAndGroups.filter((i, element) => i % 2 === 1);
+    const titles = titlesAndGroups.filter((i) => i % 2 === 0);
+    const groups = titlesAndGroups.filter((i) => i % 2 === 1);
 
     const volumeAndChapter = $('.col-1.text.text-center');
 
-    const volumes = volumeAndChapter.filter((i, element) => i % 2 === 0);
-    const chapters = volumeAndChapter.filter((i, element) => i % 2 === 1);
+    const volumes = volumeAndChapter.filter((i) => i % 2 === 0);
+    const chapters = volumeAndChapter.filter((i) => i % 2 === 1);
 
     for (let x = 0; x < dates.length; x += 1) {
       const release = new ReleaseSearchItem();

--- a/src/search/parsers/SeriesSearchParser.ts
+++ b/src/search/parsers/SeriesSearchParser.ts
@@ -21,7 +21,7 @@ export class SeriesSearchParser implements Parser<SeriesSearchItem[]> {
 
       parsedSeries.nsfw = parsedSeries.image ? false : true;
 
-      parsedSeries.title = $(elem).find('u>b').text();
+      parsedSeries.name = $(elem).find('u>b').text();
 
       parsedSeries.description = $(elem).find('.text.flex-grow-1').text();
 

--- a/src/search/search.service.ts
+++ b/src/search/search.service.ts
@@ -13,6 +13,7 @@ import fetch from 'node-fetch';
 import cheerio from 'cheerio';
 import { SeriesSearchParser } from './parsers/SeriesSearchParser';
 import SharedFunctions from 'src/shared/SharedMethods';
+import { parse } from 'date-fns';
 
 @Injectable()
 export class SearchService {
@@ -55,7 +56,6 @@ export class SearchService {
     const html = await data.text();
     const $ = cheerio.load(html);
 
-    // console.log($.text());
     const totalPages = Number(
       this.getTextInBrackets($('.d-none.d-md-inline-block').text()),
     );
@@ -69,52 +69,22 @@ export class SearchService {
       .map((element, i) => {
         return $(element).text();
       });
-    console.log(dates);
 
     const titlesAndGroups = $('.row.no-gutters > .col-4.text');
 
     const titles = titlesAndGroups.filter((i, element) => i % 2 === 0);
     const groups = titlesAndGroups.filter((i, element) => i % 2 === 1);
 
-    console.log(titles.length, groups.length);
-    titles.each((i, el) => {
-      console.log($(el).text(), 'title');
-      console.log($(el).find('a').attr('href'), 'title id');
-    });
-    groups.each((i, el) => {
-      $(el)
-        .find('a')
-        .each((k, element) => {
-          console.log($(element).text(), $(element).attr('href'), 'group', k);
-        });
-    });
-
     const volumeAndChapter = $('.col-1.text.text-center');
 
     const volumes = volumeAndChapter.filter((i, element) => i % 2 === 0);
     const chapters = volumeAndChapter.filter((i, element) => i % 2 === 1);
 
-    volumes.each((i, el) => {
-      console.log($(el).text(), 'volumes');
-    });
-
-    chapters.each((i, el) => {
-      console.log($(el).text(), 'chapters');
-    });
-
-    console.log(
-      dates.length,
-      titles.length,
-      volumes.length,
-      chapters.length,
-      groups.length,
-    );
-
     const result: ReleaseSearchItem[] = [];
 
     for (let x = 0; x < dates.length; x += 1) {
       const release = new ReleaseSearchItem();
-      release.date = new Date(); //dates[0]
+      release.date = this.stringToDate(dates[x]); //new Date(); //dates[0]
       release.title = new Title();
       release.title.title = $(titles[x]).text();
       release.title.id = SharedFunctions.getIdfromURL(
@@ -138,6 +108,10 @@ export class SearchService {
     }
 
     return [result, totalPages];
+  }
+
+  private stringToDate(s: string): Date {
+    return parse(s, 'MM/dd/yy', new Date());
   }
 
   async seriesSearch(

--- a/src/search/search.service.ts
+++ b/src/search/search.service.ts
@@ -26,14 +26,14 @@ export class SearchService {
         break;
       case ResultType.Releases:
         const [releases, pages] = await this.releasesSearch(searchInput);
-        searchResult.releases = releases;
+        searchResult.items = releases;
         searchResult.totalPages = pages;
         break;
       case ResultType.Scanlators:
         break;
       case ResultType.Series:
         const [series, totalPages] = await this.seriesSearch(searchInput);
-        searchResult.series = series;
+        searchResult.items = series;
         searchResult.totalPages = totalPages;
         break;
       default:


### PR DESCRIPTION
## Goals 🎯
* Add releases to the search query
* Make search items into a union instead of individual objects.

## Implementation Details 🚧
* Followed the way that series search was but because the results are shown on a table, the css selectors are different

## Testing Details 🔎
* :)

## Screenshots 📸
* ![image](https://user-images.githubusercontent.com/28634279/128646345-9591af41-c6f3-4715-946a-6a066c74a029.png)
