### PR TITLE
Add keep alive

### DIFF
--- a/src/app.module.ts
+++ b/src/app.module.ts
@@ -21,6 +21,9 @@ import { ScheduleModule } from '@nestjs/schedule';
     GraphQLModule.forRoot({
       autoSchemaFile: join(process.cwd(), 'src/schema.gql'),
       installSubscriptionHandlers: true,
+      subscriptions: {
+        keepAlive: 10000,
+      },
       introspection: true,
       playground: true,
       context: ({ req, res }) => ({ req, res }),


### PR DESCRIPTION
## Goals 🎯
* Heroku doesn't keep subscriptions up longer then 55 seconds so we need to send alive pings every 10 seconds.